### PR TITLE
Add a "forall" quantifier before rank-n-types

### DIFF
--- a/System/Console/Haskeline/Term.hs
+++ b/System/Console/Haskeline/Term.hs
@@ -40,7 +40,7 @@ data RunTerm = RunTerm {
 -- | Operations needed for terminal-style interaction.
 data TermOps = TermOps {
             getLayout :: IO Layout
-            , withGetEvent :: CommandMonad m => (m Event -> m a) -> m a
+            , withGetEvent :: forall m a . CommandMonad m => (m Event -> m a) -> m a
             , evalTerm :: forall m . CommandMonad m => EvalTerm m
             , saveUnusedKeys :: [Key] -> IO ()
         }


### PR DESCRIPTION
I propose to add "forall" in one place in haskeline. This improves consistency (the other data member `evalTerm` also uses explicit forall). It is planned that future GHC will require "forall" in all polymorphic fields, including those which use => arrow. For more: https://ghc.haskell.org/trac/ghc/ticket/4426. I'm open to any questions.
