### PR TITLE
Use explicit forall syntax to avoid warning

### DIFF
--- a/System/Console/Haskeline/Backend/Win32.hsc
+++ b/System/Console/Haskeline/Backend/Win32.hsc
@@ -262,7 +262,7 @@ closeHandles hs = closeHandle (hIn hs) >> closeHandle (hOut hs)
 newtype Draw m a = Draw {runDraw :: ReaderT Handles m a}
     deriving (Functor, Applicative, Monad, MonadIO, MonadException, MonadReader Handles)
 
-type DrawM a = (MonadIO m, MonadReader Layout m) => Draw m a
+type DrawM a = forall m . (MonadIO m, MonadReader Layout m) => Draw m a
 
 instance MonadTrans Draw where
     lift = Draw . lift


### PR DESCRIPTION
This is currently just a warning in GHC HEAD, but ought to be fixed
nevertheless:

```
Variable ‘m’ is implicitly quantified due to a context
Use explicit forall syntax instead.
This will become an error in GHC 7.12.
```
