### PR TITLE
Change up/down keys to cycle through history with currently typed prefix

### DIFF
--- a/System/Console/Haskeline/Emacs.hs
+++ b/System/Console/Haskeline/Emacs.hs
@@ -40,8 +40,8 @@ simpleActions = choiceCmd
             , simpleKey Delete +> change deleteNext 
             , changeFromChar insertChar
             , completionCmd (simpleChar '\t')
-            , simpleKey UpKey +> historyBack
-            , simpleKey DownKey +> historyForward
+            , simpleKey UpKey +> searchForPrefix Reverse
+            , simpleKey DownKey +> searchForPrefix Forward
             , searchHistory
             ] 
             

--- a/System/Console/Haskeline/Vi.hs
+++ b/System/Console/Haskeline/Vi.hs
@@ -55,8 +55,8 @@ simpleInsertions = choiceCmd
                    , simpleKey End +> change moveToEnd
                    , insertChars
                    , ctrlChar 'l' +> clearScreenCmd
-                   , simpleKey UpKey +> historyBack
-                   , simpleKey DownKey +> historyForward
+                   , simpleKey UpKey +> searchForPrefix Reverse
+                   , simpleKey DownKey +> searchForPrefix Forward
                    , searchHistory
                    , simpleKey KillLine +> killFromHelper (SimpleMove moveToStart)
                    , ctrlChar 'w' +> killFromHelper wordErase


### PR DESCRIPTION
I propose "searchForPrefix" to be the default behaviour for the up and down arrow keys.

-If you press up/down without typing anything, this is the same as before, as far as I can tell
-If you press up/down after typing, this behaviour is typically the behaviour you want
-If you press up/down after typing, and want the old behaviour, it is quick to kill the line and press up again
with C-a-k  or C-S-backspace in emacs mode, S in vi mode, or Ctrl+C in ghci, which is probably the vast 
majority of uses of ghci.

I get that this might be too big of a change from existing behaviour, but if you won't accept this patch, would you accept one that lets the user change the behaviour of the up/down keys in their settings file?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/haskeline/14)
<!-- Reviewable:end -->
