### PR TITLE
Removed unnecessary dependency on Cabal >= 1.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 GNUmakefile
+dist/
 dist-install
 ghc.mk

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -1,5 +1,5 @@
 Name:           haskeline
-Cabal-Version:  >=1.16
+Cabal-Version:  >=1.10
 Version:        0.7.1.3
 Category:       User Interfaces
 License:        BSD3


### PR DESCRIPTION
By removing the dependency on Cabal >= 1.16 from `haskeline.cabal`, the installation of the library with versions of GHC without Cabal >= 1.16 is simplified.

Note: If this pull request is accepted, please release a new version. Thanks!