### PR TITLE
Fix Linux to Windows cross-compile

### DIFF
--- a/System/Console/Haskeline/Directory.hsc
+++ b/System/Console/Haskeline/Directory.hsc
@@ -19,7 +19,7 @@ import qualified System.Directory
 #endif
 
 #include <windows.h>
-#include <Shlobj.h>
+#include <shlobj.h>
 
 ##if defined(i386_HOST_ARCH)
 ## define WINDOWS_CCONV stdcall


### PR DESCRIPTION
The #include of <Shlobj.h> doesn't work when cross-compiling from
Linux to Windows because the Linux file system is case sensitive and
on Linux the file is <shlobj.h>. This change should not affect Windows
builds because the Windows file system is case insensitive.