### PR TITLE
Generalise constraints for InputT instances

### DIFF
--- a/System/Console/Haskeline/InputT.hs
+++ b/System/Console/Haskeline/InputT.hs
@@ -47,18 +47,11 @@ newtype InputT m a = InputT {unInputT ::
                                 (ReaderT (IORef KillRing)
                                 (ReaderT Prefs
                                 (ReaderT (Settings m) m)))) a}
-                            deriving (Monad, MonadIO, MonadException)
+                            deriving (Functor, Applicative, Monad, MonadIO, MonadException)
                 -- NOTE: we're explicitly *not* making InputT an instance of our
                 -- internal MonadState/MonadReader classes.  Otherwise haddock
                 -- displays those instances to the user, and it makes it seem like
                 -- we implement the mtl versions of those classes.
-
-instance Monad m => Functor (InputT m) where
-    fmap = liftM
-
-instance Monad m => Applicative (InputT m) where
-    pure = return
-    (<*>) = ap
 
 instance MonadTrans InputT where
     lift = InputT . lift . lift . lift . lift . lift


### PR DESCRIPTION
I'm not sure why the code was written the way it was, but it seems we
can do better by letting GHC directly reuse `ReaderT`'s instances as
well as relaxing the constraints from

    instance Monad m       => Functor     (InputT m)
    instance Monad m       => Applicative (InputT m)
    instance Monad m       => Monad       (InputT m)

to

    instance Functor     m => Functor     (InputT m)
    instance Applicative m => Applicative (InputT m)
    instance Monad       m => Monad       (InputT m)

This looks the same on GHC 7.8 (pre-AMP) as well as on GHC 7.10 (post-AMP)