### PR TITLE
Canonicalise AMP instances

### DIFF
--- a/System/Console/Haskeline/Command.hs
+++ b/System/Console/Haskeline/Command.hs
@@ -66,11 +66,11 @@ instance Monad m => Functor (CmdM m) where
     fmap = liftM
 
 instance Monad m => Applicative (CmdM m) where
-    pure  = return
+    pure  = Result
     (<*>) = ap
 
 instance Monad m => Monad (CmdM m) where
-    return = Result
+    return = pure
 
     GetKey km >>= g = GetKey $ fmap (>>= g) km
     DoEffect e f >>= g = DoEffect e (f >>= g)

--- a/System/Console/Haskeline/Monads.hs
+++ b/System/Console/Haskeline/Monads.hs
@@ -77,11 +77,11 @@ instance Monad m => Functor (StateT s m) where
     fmap  = liftM
 
 instance Monad m => Applicative (StateT s m) where
-    pure  = return
+    pure x = StateT $ \s -> return $ \f -> f x s
     (<*>) = ap
 
 instance Monad m => Monad (StateT s m) where
-    return x = StateT $ \s -> return $ \f -> f x s
+    return = pure
     StateT f >>= g = StateT $ \s -> do
         useX <- f s
         useX $ \x s' -> getStateTFunc (g x) s'


### PR DESCRIPTION
This flips the AMP instance definitions into the recommended canonical form and makes the code a bit more future proof.