### PR TITLE
Relax upper bound to allow upcoming `transformers-0.5`

### DIFF
--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -52,7 +52,7 @@ flag legacy-encoding
 Library
     Build-depends: base >=4.3 && < 4.10, containers>=0.4 && < 0.6,
                    directory>=1.1 && < 1.3, bytestring>=0.9 && < 0.11,
-                   filepath >= 1.2 && < 1.5, transformers >= 0.2 && < 0.5
+                   filepath >= 1.2 && < 1.5, transformers >= 0.2 && < 0.6
     Default-Language: Haskell98
     Default-Extensions: 
                 ForeignFunctionInterface, Rank2Types, FlexibleInstances,


### PR DESCRIPTION
GHC 8.0 will ship with the not yet released `transformers-0.5.0.0`
release.