### PR TITLE
Fix the behavior of unix-word-rubout (C-w) for emacs bindings

### DIFF
--- a/System/Console/Haskeline/Emacs.hs
+++ b/System/Console/Haskeline/Emacs.hs
@@ -89,7 +89,7 @@ rotatePaste im = get >>= loop
 wordRight, wordLeft, bigWordLeft :: InsertMode -> InsertMode
 wordRight = goRightUntil (atStart (not . isAlphaNum))
 wordLeft = goLeftUntil (atStart isAlphaNum)
-bigWordLeft = goLeftUntil (atStart isSpace)
+bigWordLeft = goLeftUntil (atStart (not . isSpace))
 
 modifyWord :: ([Grapheme] -> [Grapheme]) -> InsertMode -> InsertMode
 modifyWord f im = IMode (reverse (f ys1) ++ xs) ys2


### PR DESCRIPTION
Haskeline differs from readline in C-w behaviour: 
* In readline unix-word-rubout (C-w) deleted one word to the left of the cursor, leaving the cursor in the position of the first letter of that word. (`123  45|6` -> `123  |6`)
* However, in ghci, it deletes the whitespaces before the word as well. (`123  45|6` -> `123|6`)