### PR TITLE
Properly process Unicode key events on Windows

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,5 @@
+next:
+   * Properly process Unicode key events on Windows.
 Changed in version 0.7.3.1:
    * Properly disable echoing in getPassword when running in MinTTY.
    * Use `cast` from Data.Typeable instead of Data.Dynamic.

--- a/System/Console/Haskeline/Backend/Win32.hsc
+++ b/System/Console/Haskeline/Backend/Win32.hsc
@@ -73,8 +73,12 @@ consoleHandles = do
 
 
 processEvent :: InputEvent -> Maybe Event
-processEvent KeyEvent {keyDown = True, unicodeChar = c, virtualKeyCode = vc,
+processEvent KeyEvent {keyDown = kd, unicodeChar = c, virtualKeyCode = vc,
                     controlKeyState = cstate}
+    | kd || ((testMod (#const LEFT_ALT_PRESSED) || vc == (#const VK_MENU))
+             && c /= '\NUL')
+      -- Make sure not to ignore Unicode key events! The Unicode character might
+      -- only be emitted on a keyup event. See also GH issue #54.
     = fmap (\e -> KeyInput [Key modifier' e]) $ keyFromCode vc `mplus` simpleKeyChar
   where
     simpleKeyChar = guard (c /= '\NUL') >> return (KeyChar c)


### PR DESCRIPTION
Fixes #54 by adopting the strategy proposed in https://github.com/judah/haskeline/issues/54#issuecomment-280510726: refine the filtering criteria in `processEvent` so that it does not discard a keyup event if it comes from holding the left alt key and also emits a valid Unicode character, [mimicking the strategy present in `libuv`](https://github.com/libuv/libuv/blob/02dcde08386441d5a89dbcb602a1ad367a506cc0/src/win/tty.c#L730-L735).