### PR TITLE
Use 0xffffffff in place of -1 to MessageBeep

### DIFF
--- a/System/Console/Haskeline/Backend/Win32.hsc
+++ b/System/Console/Haskeline/Backend/Win32.hsc
@@ -226,7 +226,8 @@ writeConsole h str = writeConsole' >> writeConsole h ys
 foreign import WINDOWS_CCONV "windows.h MessageBeep" c_messageBeep :: UINT -> IO Bool
 
 messageBeep :: IO ()
-messageBeep = c_messageBeep (-1) >> return ()-- intentionally ignore failures.
+messageBeep = c_messageBeep simpleBeep >> return ()-- intentionally ignore failures.
+  where simpleBeep = 0xffffffff
 
 
 ----------


### PR DESCRIPTION
MessageBeep expects an unsigned argument, leading to a
literal-out-of-range error previously.