### PR TITLE
Move away from Chan to STM

### DIFF
--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -43,7 +43,7 @@ Library
     -- We require ghc>=7.4.1 (base>=4.5) to use the base library encodings, even
     -- though it was implemented in earlier releases, due to GHC bug #5436 which
     -- wasn't fixed until 7.4.1
-    Build-depends: base >=4.5 && < 4.11, containers>=0.4 && < 0.6,
+    Build-depends: base >=4.5 && < 4.12, containers>=0.4 && < 0.6,
                    directory>=1.1 && < 1.4, bytestring>=0.9 && < 0.11,
                    filepath >= 1.2 && < 1.5, transformers >= 0.2 && < 0.6,
                    process >= 1.0 && < 1.7, stm >= 2.4 && < 2.5

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -46,7 +46,7 @@ Library
     Build-depends: base >=4.5 && < 4.11, containers>=0.4 && < 0.6,
                    directory>=1.1 && < 1.4, bytestring>=0.9 && < 0.11,
                    filepath >= 1.2 && < 1.5, transformers >= 0.2 && < 0.6,
-                   process >= 1.0 && < 1.7
+                   process >= 1.0 && < 1.7, stm >= 2.4 && < 2.5
     Default-Language: Haskell98
     Default-Extensions:
                 ForeignFunctionInterface, Rank2Types, FlexibleInstances,


### PR DESCRIPTION
The isEmptyChan broken has been long known to be broken. Moreover, the atomicity guarantees provided by STM simplify things a bit.