### PR TITLE
Add configurable mode indicator for the vi editing style

### DIFF
--- a/System/Console/Haskeline/Command.hs
+++ b/System/Console/Haskeline/Command.hs
@@ -35,13 +35,13 @@ import Control.Monad.Trans.Class
 import System.Console.Haskeline.LineState
 import System.Console.Haskeline.Key
 
-data Effect = LineChange (Prefix -> LineChars)
+data Effect = LineChange (ModePrefixes -> Prefix -> LineChars)
               | PrintLines [String]
               | ClearScreen
               | RingBell
 
 lineChange :: LineState s => s -> Effect
-lineChange = LineChange . flip lineChars
+lineChange s = LineChange $ \mp p -> lineChars mp p s
 
 data KeyMap a = KeyMap {lookupKM :: Key -> Maybe (KeyConsumed a)}
 

--- a/System/Console/Haskeline/Command/Completion.hs
+++ b/System/Console/Haskeline/Command/Completion.hs
@@ -105,7 +105,7 @@ pageCompletions wws@(w:ws) = do
         ]
   where
     oneLine = clearMessage >> effect (PrintLines [w]) >> pageCompletions ws
-    clearMessage = effect $ LineChange $ const ([],[])
+    clearMessage = effect . LineChange $ \_ _ -> ([],[])
 
 printPage :: MonadReader Layout m => [String] -> CmdM m ()
 printPage ls = do

--- a/System/Console/Haskeline/Command/History.hs
+++ b/System/Console/Haskeline/Command/History.hs
@@ -88,7 +88,7 @@ directionName Forward = "i-search"
 directionName Reverse = "reverse-i-search"
 
 instance LineState SearchMode where
-    beforeCursor _ sm = beforeCursor prefix (foundHistory sm)
+    beforeCursor _ _ sm = beforeCursor noModePrefixes prefix (foundHistory sm)
         where 
             prefix = stringToGraphemes ("(" ++ directionName (direction sm) ++ ")`")
                             ++ searchTerm sm ++ stringToGraphemes "': "

--- a/System/Console/Haskeline/Prefs.hs
+++ b/System/Console/Haskeline/Prefs.hs
@@ -25,12 +25,16 @@ one field of the 'Prefs' datatype; field names are case-insensitive and
 unparseable lines are ignored.  For example:
 
 > editMode: Vi
+> viCommandModePrefix: ":"
+> viInsertModePrefix: "+"
 > completionType: MenuCompletion
 > maxhistorysize: Just 40
 
 -}
 data Prefs = Prefs { bellStyle :: !BellStyle,
                      editMode :: !EditMode,
+                     viCommandModePrefix :: String,
+                     viInsertModePrefix :: String,
                      maxHistorySize :: !(Maybe Int),
                      historyDuplicates :: HistoryDuplicates,
                      completionType :: !CompletionType,
@@ -61,6 +65,7 @@ data BellStyle = NoBell | VisualBell | AudibleBell
 data EditMode = Vi | Emacs
                     deriving (Show,Read)
 
+
 data HistoryDuplicates = AlwaysAdd | IgnoreConsecutive | IgnoreAll
                     deriving (Show,Read)
 
@@ -70,6 +75,8 @@ defaultPrefs :: Prefs
 defaultPrefs = Prefs {bellStyle = AudibleBell,
                       maxHistorySize = Just 100,
                       editMode = Emacs,
+                      viCommandModePrefix = "",
+                      viInsertModePrefix = "",
                       completionType = ListCompletion,
                       completionPaging = True,
                       completionPromptLimit = Just 100,
@@ -91,6 +98,8 @@ readMaybe str = case reads str of
 settors :: [(String, String -> Prefs -> Prefs)]
 settors = [("bellstyle", mkSettor $ \x p -> p {bellStyle = x})
           ,("editmode", mkSettor $ \x p -> p {editMode = x})
+          ,("viinsertmodeprefix", mkSettor $ \x p -> p {viInsertModePrefix = x})
+          ,("vicommandmodeprefix", mkSettor $ \x p -> p {viCommandModePrefix = x})
           ,("maxhistorysize", mkSettor $ \x p -> p {maxHistorySize = x})
           ,("completiontype", mkSettor $ \x p -> p {completionType = x})
           ,("completionpaging", mkSettor $ \x p -> p {completionPaging = x})

--- a/System/Console/Haskeline/Vi.hs
+++ b/System/Console/Haskeline/Vi.hs
@@ -406,8 +406,10 @@ searchText :: SearchEntry -> [Grapheme]
 searchText SearchEntry {entryState = IMode xs ys} = reverse xs ++ ys
 
 instance LineState SearchEntry where
-    beforeCursor prefix se = beforeCursor (prefix ++ stringToGraphemes [searchChar se])
-                                (entryState se)
+    beforeCursor _ prefix se = beforeCursor
+        noModePrefixes
+        (prefix ++ stringToGraphemes [searchChar se])
+        (entryState se)
     afterCursor = afterCursor . entryState
 
 viEnterSearch :: Monad m => Char -> Direction


### PR DESCRIPTION
Fixes #38.

When using the vi editing style, the presence of insert-mode or command-mode is indicated before the usual prefix by a user configurable string.

The emacs editing style, and all other modes (e.g. search-mode, arg-mode) are unaffected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/haskeline/78)
<!-- Reviewable:end -->
