### PR TITLE
Bump upper bound on unix to < 2.9

### DIFF
--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -95,7 +95,7 @@ Library
         install-includes: win_console.h
         cpp-options: -DMINGW
     } else {
-        Build-depends: unix>=2.0 && < 2.8
+        Build-depends: unix>=2.0 && < 2.9
         Other-modules:
                 System.Console.Haskeline.Backend.Posix
                 System.Console.Haskeline.Backend.Posix.Encoder


### PR DESCRIPTION
See https://ghc.haskell.org/trac/ghc/ticket/15042.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/haskeline/82)
<!-- Reviewable:end -->
