### PR TITLE
Allow to bind incremental search to a key

### DIFF
--- a/System/Console/Haskeline/Emacs.hs
+++ b/System/Console/Haskeline/Emacs.hs
@@ -42,6 +42,8 @@ simpleActions = choiceCmd
             , completionCmd (simpleChar '\t')
             , simpleKey UpKey +> historyBack
             , simpleKey DownKey +> historyForward
+            , simpleKey UpOrSearch +> searchForPrefix Reverse
+            , simpleKey DownOrSearch +> searchForPrefix Forward
             , searchHistory
             ] 
             

--- a/System/Console/Haskeline/Key.hs
+++ b/System/Console/Haskeline/Key.hs
@@ -39,6 +39,7 @@ data BaseKey = KeyChar Char
              -- TODO: is KillLine really a key?
              | KillLine | Home | End | PageDown | PageUp
              | Backspace | Delete
+             | UpOrSearch | DownOrSearch
             deriving (Show,Eq,Ord)
 
 simpleKey :: BaseKey -> Key
@@ -77,6 +78,8 @@ specialKeys = [("left",LeftKey)
               ,("tab",KeyChar '\t')
               ,("esc",KeyChar '\ESC')
               ,("escape",KeyChar '\ESC')
+              ,("up_or_search",UpOrSearch)
+              ,("down_or_search",DownOrSearch)
               ]
 
 parseModifiers :: [String] -> BaseKey -> Key

--- a/System/Console/Haskeline/Vi.hs
+++ b/System/Console/Haskeline/Vi.hs
@@ -57,6 +57,8 @@ simpleInsertions = choiceCmd
                    , ctrlChar 'l' +> clearScreenCmd
                    , simpleKey UpKey +> historyBack
                    , simpleKey DownKey +> historyForward
+                   , simpleKey UpOrSearch +> searchForPrefix Reverse
+                   , simpleKey DownOrSearch +> searchForPrefix Forward
                    , searchHistory
                    , simpleKey KillLine +> killFromHelper (SimpleMove moveToStart)
                    , ctrlChar 'w' +> killFromHelper wordErase


### PR DESCRIPTION
#87 Well, `KillLine` isn't a real key and it's a precedent, I think. This patch is the simplest solution that I can imagine, but I still want to make it more closer to Zsh by extending `searchForPrefix` state with previous cursor position.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/haskeline/90)
<!-- Reviewable:end -->
