### PR TITLE
 Add fallbackCompletion to support module completion in ghci :add

### DIFF
--- a/System/Console/Haskeline/Completion.hs
+++ b/System/Console/Haskeline/Completion.hs
@@ -3,6 +3,7 @@ module System.Console.Haskeline.Completion(
                             Completion(..),
                             noCompletion,
                             simpleCompletion,
+                            fallbackCompletion,
                             -- * Word completion
                             completeWord,
                             completeWordWithPrev,
@@ -188,3 +189,12 @@ fixPath ('~':c:path) | isPathSeparator c = do
     home <- getHomeDirectory
     return (home </> path)
 fixPath path = return path
+
+-- | If the first completer produces no suggestions, fallback to the second
+-- completer's output.
+fallbackCompletion :: Monad m => CompletionFunc m -> CompletionFunc m -> CompletionFunc m
+fallbackCompletion a b input = do
+    aCompletions <- a input
+    if null (snd aCompletions)
+        then b input
+        else return aCompletions


### PR DESCRIPTION
GHCi's `:add` command supports both file paths and module names, and I want to patch it to tab complete both.

The first commit is present in GHC's submodule on master, but not in this repo, despite it being listed as the official upstream for haskeline. I'm not sure what's up with that, so if I'm submitting this patch to the wrong place just let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/haskeline/91)
<!-- Reviewable:end -->
