### PR TITLE
Simplify and speed up the Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-# Based on https://github.com/hvr/multi-ghc-travis
-#
-# NB: don't set `language: haskell` here
+# Use a lightweight base image; we provide our own build tools.
+language: c
 env:
  - CABALVER=1.24 GHCVER=8.0.1
  - CABALVER=1.24 GHCVER=8.0.2
@@ -8,23 +7,27 @@ env:
  - CABALVER=2.2 GHCVER=8.4.3
  - CABALVER=2.4 GHCVER=8.6.1
 
-# Note: the distinction between `before_install` and `install` is not important.
-before_install:
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+matrix:
+  include:
+  - env: CABALVER=1.24 GHCVER=8.0.1
+    addons: {apt: {packages: [cabal-install-1.24, ghc-8.0.1], sources: [hvr-ghc]}}
+  - env: CABALVER=1.24 GHCVER=8.0.2
+    addons: {apt: {packages: [cabal-install-1.24, ghc-8.0.2], sources: [hvr-ghc]}}
+  - env: CABALVER=2.0 GHCVER=8.2.2
+    addons: {apt: {packages: [cabal-install-2.0, ghc-8.2.2], sources: [hvr-ghc]}}
+  - env: CABALVER=2.2 GHCVER=8.4.3
+    addons: {apt: {packages: [cabal-install-2.2, ghc-8.4.3], sources: [hvr-ghc]}}
+  - env: CABALVER=2.4 GHCVER=8.6.1
+    addons: {apt: {packages: [cabal-install-2.4, ghc-8.6.1], sources: [hvr-ghc]}}
 
 install:
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - travis_retry cabal update
  - cabal install --only-dependencies
 
-# Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
- - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal --version
  - cabal configure -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal check


### PR DESCRIPTION
- Use Travis's build-in apt support
- Use `language: c` explicitly
- Remove unnecessary `cabal` invocations
- Remove the separate `before_install` step