### PR TITLE
Define tests executables in cabal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 dist-install
 ghc.mk
 .stack-work
+myhist

--- a/examples/Test.hs
+++ b/examples/Test.hs
@@ -2,7 +2,6 @@ module Main where
 
 import System.Console.Haskeline
 import System.Environment
-import Control.Exception (AsyncException(..))
 
 {--
 Testing the line-input functions and their interaction with ctrl-c signals.
@@ -29,8 +28,9 @@ main = do
                 _ -> getInputLine
         runInputT mySettings $ withInterrupt $ loop inputFunc 0
     where
+        loop :: (String -> InputT IO (Maybe String)) -> Int -> InputT IO ()
         loop inputFunc n = do
-            minput <-  handle (\Interrupt -> return (Just "Caught interrupted"))
+            minput <-  handleInterrupt (return (Just "Caught interrupted"))
                         $ inputFunc (show n ++ ":")
             case minput of
                 Nothing -> return ()

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -114,9 +114,10 @@ Executable tests
     hs-source-dirs: tests
     Default-Language: Haskell98
 
-    if (os(windows))
+    if os(windows)
         -- this is dummy module, tests don't compile on windows
         Main-Is: Windows.hs
+        Build-depends: base
     else
         Main-Is:    Unit.hs
         Build-depends: base, containers, text, bytestring, HUnit, process, unix

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -110,26 +110,20 @@ Library
     }
     ghc-options: -Wall -Werror
 
-
 Executable tests
-    Build-depends: base, containers, text, bytestring, HUnit, process, unix
-    Default-Language: Haskell2010
-    Default-Extensions:
-                ForeignFunctionInterface, Rank2Types, FlexibleInstances,
-                TypeSynonymInstances
-                FlexibleContexts, ExistentialQuantification
-                ScopedTypeVariables, GeneralizedNewtypeDeriving
-                StandaloneDeriving
-                MultiParamTypeClasses,
-                UndecidableInstances
-                ScopedTypeVariables, CPP, DeriveDataTypeable,
-                PatternGuards
     hs-source-dirs: tests
-    Main-Is:    Unit.hs
-    Other-Modules: RunTTY, Pty
-    ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-signatures
+    Default-Language: Haskell98
 
--- The following program is used by unit tests in `tests`
+    if (os(windows))
+        -- this is dummy module, tests don't compile on windows
+        Main-Is: Windows.hs
+    else
+        Main-Is:    Unit.hs
+        Build-depends: base, containers, text, bytestring, HUnit, process, unix
+        Other-Modules: RunTTY, Pty
+        ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-signatures
+
+-- The following program is used by unit tests in `tests` executable
 Executable examples-Test
     Build-depends: base, containers, haskeline
     Default-Language: Haskell2010

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -108,4 +108,31 @@ Library
             cpp-options: -DUSE_TERMIOS_H
         }
     }
-    ghc-options: -Wall
+    ghc-options: -Wall -Werror
+
+
+Executable tests
+    Build-depends: base, containers, text, bytestring, HUnit, process, unix
+    Default-Language: Haskell2010
+    Default-Extensions:
+                ForeignFunctionInterface, Rank2Types, FlexibleInstances,
+                TypeSynonymInstances
+                FlexibleContexts, ExistentialQuantification
+                ScopedTypeVariables, GeneralizedNewtypeDeriving
+                StandaloneDeriving
+                MultiParamTypeClasses,
+                UndecidableInstances
+                ScopedTypeVariables, CPP, DeriveDataTypeable,
+                PatternGuards
+    hs-source-dirs: tests
+    Main-Is:    Unit.hs
+    Other-Modules: RunTTY, Pty
+    ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-signatures
+
+-- The following program is used by unit tests in `tests`
+Executable examples-Test
+    Build-depends: base, containers, haskeline
+    Default-Language: Haskell2010
+    hs-source-dirs: examples
+    Main-Is: Test.hs
+    ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-signatures

--- a/run-unit-tests.sh
+++ b/run-unit-tests.sh
@@ -1,0 +1,1 @@
+stack exec tests $(stack path --local-install-root)/bin/examples-Test

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,3 @@ packages:
 
 extra-deps:
 - exceptions-0.10.0
-
-ghc-options:
-  "$locals": -Wall -Werror

--- a/tests/Pty.hs
+++ b/tests/Pty.hs
@@ -18,9 +18,7 @@ import Foreign.Marshal.Alloc
 import Foreign.C.Error
 import Foreign.C.Types
 import Foreign.Ptr
-import Control.Exception
 import Control.Concurrent
-import Control.Monad (liftM2)
 
 -- Run the given command in a pseudoterminal, and return its output chunks.
 -- Read the initial output, then feed the given input to it
@@ -38,7 +36,7 @@ runCommandInPty prog args env inputs = do
     setFdOption fd NonBlockingRead True
     outputs <- mapM (inputOutput fd) inputs
     signalProcess killProcess pid
-    status <- getProcessStatus True False pid
+    _status <- getProcessStatus True False pid
     closeFd fd
     return (firstOutput : outputs)
 

--- a/tests/RunTTY.hs
+++ b/tests/RunTTY.hs
@@ -13,12 +13,11 @@ module RunTTY (Invocation(..),
 
 import Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
-import System.Posix.Env.ByteString hiding (setEnv)
 import System.Process
 import Control.Concurrent
 import System.IO
 import Test.HUnit
-import Control.Monad (unless, liftM2, zipWithM_)
+import Control.Monad (unless)
 
 import Pty
 

--- a/tests/Windows.hs
+++ b/tests/Windows.hs
@@ -1,0 +1,2 @@
+-- dummy file to file to fill in the tests project in cabal for windows
+main = return ()


### PR DESCRIPTION
* Added two executables to the cabal file. One is the Test program from the examples directory that is used by the unit tests. The second are the unit tests. The unit tests depend on the `unix` package and are setup in the cabal file not to build on windows.

* added run-unit-tests.sh that runs the unit tests, provided they are built

There is one unit test failing independent of my changes.

### Failure in: 0:interaction:2:tab completion:0
tests/RunTTY.hs:102
expected: ["dummy-\206\188\206\177\207\131/\r\nbar   \207\130\206\181\207\129\207\132\r\n0:dummy-\206\188\206\177\207\131/"]
 but got: ["dummy-\206\188\a\a"]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/haskeline/102)
<!-- Reviewable:end -->
