### PR TITLE
Define executable targets in the cabal file for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 dist-install
 ghc.mk
 .stack-work
+myhist

--- a/examples/Test.hs
+++ b/examples/Test.hs
@@ -2,7 +2,6 @@ module Main where
 
 import System.Console.Haskeline
 import System.Environment
-import Control.Exception (AsyncException(..))
 
 {--
 Testing the line-input functions and their interaction with ctrl-c signals.
@@ -29,8 +28,9 @@ main = do
                 _ -> getInputLine
         runInputT mySettings $ withInterrupt $ loop inputFunc 0
     where
+        loop :: (String -> InputT IO (Maybe String)) -> Int -> InputT IO ()
         loop inputFunc n = do
-            minput <-  handle (\Interrupt -> return (Just "Caught interrupted"))
+            minput <-  handleInterrupt (return (Just "Caught interrupted"))
                         $ inputFunc (show n ++ ":")
             case minput of
                 Nothing -> return ()

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -114,9 +114,10 @@ Executable tests
     hs-source-dirs: tests
     Default-Language: Haskell98
 
-    if (os(windows))
+    if os(windows)
         -- this is dummy module, tests don't compile on windows
         Main-Is: Windows.hs
+        Build-depends: base
     else
         Main-Is:    Unit.hs
         Build-depends: base, containers, text, bytestring, HUnit, process, unix

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -108,7 +108,6 @@ Library
             cpp-options: -DUSE_TERMIOS_H
         }
     }
-    ghc-options: -Wall -Werror
 
 Executable tests
     hs-source-dirs: tests
@@ -122,7 +121,6 @@ Executable tests
         Main-Is:    Unit.hs
         Build-depends: base, containers, text, bytestring, HUnit, process, unix
         Other-Modules: RunTTY, Pty
-        ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-signatures
 
 -- The following program is used by unit tests in `tests` executable
 Executable examples-Test
@@ -130,4 +128,3 @@ Executable examples-Test
     Default-Language: Haskell2010
     hs-source-dirs: examples
     Main-Is: Test.hs
-    ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-signatures

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -110,26 +110,20 @@ Library
     }
     ghc-options: -Wall -Werror
 
-
 Executable tests
-    Build-depends: base, containers, text, bytestring, HUnit, process, unix
-    Default-Language: Haskell2010
-    Default-Extensions:
-                ForeignFunctionInterface, Rank2Types, FlexibleInstances,
-                TypeSynonymInstances
-                FlexibleContexts, ExistentialQuantification
-                ScopedTypeVariables, GeneralizedNewtypeDeriving
-                StandaloneDeriving
-                MultiParamTypeClasses,
-                UndecidableInstances
-                ScopedTypeVariables, CPP, DeriveDataTypeable,
-                PatternGuards
     hs-source-dirs: tests
-    Main-Is:    Unit.hs
-    Other-Modules: RunTTY, Pty
-    ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-signatures
+    Default-Language: Haskell98
 
--- The following program is used by unit tests in `tests`
+    if (os(windows))
+        -- this is dummy module, tests don't compile on windows
+        Main-Is: Windows.hs
+    else
+        Main-Is:    Unit.hs
+        Build-depends: base, containers, text, bytestring, HUnit, process, unix
+        Other-Modules: RunTTY, Pty
+        ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-signatures
+
+-- The following program is used by unit tests in `tests` executable
 Executable examples-Test
     Build-depends: base, containers, haskeline
     Default-Language: Haskell2010

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -108,4 +108,31 @@ Library
             cpp-options: -DUSE_TERMIOS_H
         }
     }
-    ghc-options: -Wall
+    ghc-options: -Wall -Werror
+
+
+Executable tests
+    Build-depends: base, containers, text, bytestring, HUnit, process, unix
+    Default-Language: Haskell2010
+    Default-Extensions:
+                ForeignFunctionInterface, Rank2Types, FlexibleInstances,
+                TypeSynonymInstances
+                FlexibleContexts, ExistentialQuantification
+                ScopedTypeVariables, GeneralizedNewtypeDeriving
+                StandaloneDeriving
+                MultiParamTypeClasses,
+                UndecidableInstances
+                ScopedTypeVariables, CPP, DeriveDataTypeable,
+                PatternGuards
+    hs-source-dirs: tests
+    Main-Is:    Unit.hs
+    Other-Modules: RunTTY, Pty
+    ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-signatures
+
+-- The following program is used by unit tests in `tests`
+Executable examples-Test
+    Build-depends: base, containers, haskeline
+    Default-Language: Haskell2010
+    hs-source-dirs: examples
+    Main-Is: Test.hs
+    ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-signatures

--- a/run-unit-tests.sh
+++ b/run-unit-tests.sh
@@ -1,0 +1,1 @@
+stack exec tests $(stack path --local-install-root)/bin/examples-Test

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,3 @@ packages:
 
 extra-deps:
 - exceptions-0.10.0
-
-ghc-options:
-  "$locals": -Wall -Werror

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,3 +5,6 @@ packages:
 
 extra-deps:
 - exceptions-0.10.0
+
+ghc-options:
+  "$locals": -Wall -Werror

--- a/tests/Pty.hs
+++ b/tests/Pty.hs
@@ -18,9 +18,7 @@ import Foreign.Marshal.Alloc
 import Foreign.C.Error
 import Foreign.C.Types
 import Foreign.Ptr
-import Control.Exception
 import Control.Concurrent
-import Control.Monad (liftM2)
 
 -- Run the given command in a pseudoterminal, and return its output chunks.
 -- Read the initial output, then feed the given input to it
@@ -38,7 +36,7 @@ runCommandInPty prog args env inputs = do
     setFdOption fd NonBlockingRead True
     outputs <- mapM (inputOutput fd) inputs
     signalProcess killProcess pid
-    status <- getProcessStatus True False pid
+    _status <- getProcessStatus True False pid
     closeFd fd
     return (firstOutput : outputs)
 

--- a/tests/RunTTY.hs
+++ b/tests/RunTTY.hs
@@ -13,12 +13,11 @@ module RunTTY (Invocation(..),
 
 import Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
-import System.Posix.Env.ByteString hiding (setEnv)
 import System.Process
 import Control.Concurrent
 import System.IO
 import Test.HUnit
-import Control.Monad (unless, liftM2, zipWithM_)
+import Control.Monad (unless)
 
 import Pty
 

--- a/tests/RunTTY.hs
+++ b/tests/RunTTY.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE RecordWildCards #-}
 -- This module provides an interface for testing the output
 -- of programs that expect to be run in a terminal.
-module RunTTY (Invocation(..), 
-            runInvocation, 
+module RunTTY (Invocation(..),
+            runInvocation,
             assertInvocation,
             testI,
             setLang,
@@ -17,7 +17,6 @@ import System.Process
 import Control.Concurrent
 import System.IO
 import Test.HUnit
-import Control.Monad (unless)
 
 import Pty
 
@@ -31,19 +30,23 @@ data Invocation = Invocation {
 
 setEnv :: String -> String -> Invocation -> Invocation
 setEnv var val Invocation {..} = Invocation{
-        environment = (var,val) : Prelude.filter ((/=var).fst) environment 
+        environment = (var,val) : Prelude.filter ((/=var).fst) environment
         ,..
         }
 
+setLang :: String -> Invocation -> Invocation
 setLang = setEnv "LANG"
+setTerm :: String -> Invocation -> Invocation
 setTerm = setEnv "TERM"
 
 
+setUTF8 :: Invocation -> Invocation
 setUTF8 = setLang "en_US.UTF-8"
+setLatin1 :: Invocation -> Invocation
 setLatin1 = setLang "en_US.ISO8859-1"
 
 
-runInvocation :: Invocation 
+runInvocation :: Invocation
         -> [B.ByteString] -- Input chunks.  (We pause after each chunk to
                         -- simulate real user input and prevent Haskeline
                         -- from coalescing the changes.)
@@ -64,7 +67,7 @@ runInvocation Invocation {..} inputs
     hClose inH
     lastOutput <- getOutput outH -- output triggered by EOF, if any
     terminateProcess ph
-    waitForProcess ph
+    _ <- waitForProcess ph
     return $ firstOutput : outputs
                 ++ if B.null lastOutput then [] else [lastOutput]
 
@@ -89,6 +92,7 @@ assertInvocation i input expectedOutput = do
 -- Remove CRLFs from output, since tty translates all LFs into CRLF.
 -- (TODO: I'd like to just unset ONLCR in the slave tty, but
 -- System.Posix.Terminal doesn't support that flag.)
+fixOutput :: B.ByteString -> B.ByteString
 fixOutput = BC.pack . loop . BC.unpack
   where
     loop ('\r':'\n':rest) = '\n' : loop rest
@@ -100,36 +104,6 @@ assertSameList [] [] = return ()
 assertSameList (x:xs) (y:ys)
     | x == y = assertSameList xs ys
 assertSameList xs ys = xs @=? ys -- cause error to be thrown
-
-assertSame :: B.ByteString -> B.ByteString -> Assertion
-assertSame expected actual = do
-    let (same,expected',actual') = commonPrefix expected actual
-    unless (B.null expected'  && B.null actual') $ assertFailure
-        $ "With common prefix " ++ show same ++ "\n"
-        ++ "  expected: " ++ show expected' ++ "\n"
-        ++ "   but got: " ++ show actual'
-        ++ if normalizeErrs expected' == normalizeErrs actual'
-            then "\n  (Same except for error chars)"
-            else ""
-
-
-commonPrefix :: B.ByteString -> B.ByteString
-    -> (B.ByteString, B.ByteString,B.ByteString)
-commonPrefix xs ys = loop 0
-  where
-    loop k
-        | k < B.length xs && k < B.length ys
-            && xs `B.index` k == ys `B.index` k
-            = loop (k+1)
-        | otherwise = (B.take k xs, B.drop k xs, B.drop k ys)
-
-normalizeErrs = BC.pack . loop . BC.unpack
-  where
-    loop ('\239':'\191':'\189':rest) = loop rest
-    loop ('?':rest) = loop rest
-    loop (c:cs) = c : loop cs
-    loop [] = []
-
 
 testI :: Invocation -> [B.ByteString] -> [B.ByteString] -> Test
 testI i inp outp = test $ assertInvocation i inp outp

--- a/tests/Windows.hs
+++ b/tests/Windows.hs
@@ -1,0 +1,2 @@
+-- dummy file to file to fill in the tests project in cabal for windows
+main = return ()


### PR DESCRIPTION
This change is motivated to make it easier to run the unit tests:

* defined two executable targets in the cabal file
* added run_unit_tests.sh script

one test is failing independent of my changes

### Failure in: 0:interaction:2:tab completion:0
tests/RunTTY.hs:106
expected: ["dummy-\206\188\206\177\207\131/\r\nbar   \207\130\206\181\207\129\207\132\r\n0:dummy-\206\188\206\177\207\131/"]
 but got: ["dummy-\206\188\a\a"]