### PR TITLE
Declare tentative compatibility with unreleased GHC 8.8/base-4.13

### DIFF
--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -42,7 +42,7 @@ Library
     -- We require ghc>=7.4.1 (base>=4.5) to use the base library encodings, even
     -- though it was implemented in earlier releases, due to GHC bug #5436 which
     -- wasn't fixed until 7.4.1
-    Build-depends: base >=4.9 && < 4.13, containers>=0.4 && < 0.7,
+    Build-depends: base >=4.9 && < 4.14, containers>=0.4 && < 0.7,
                    directory>=1.1 && < 1.4, bytestring>=0.9 && < 0.11,
                    filepath >= 1.2 && < 1.5, transformers >= 0.4 && < 0.6,
                    process >= 1.0 && < 1.7, stm >= 2.4 && < 2.6


### PR DESCRIPTION
This is needed for early integration w/ GHC HEAD for the 
upcoming GHC 8.8/base-4.13

Please do not upload this to Hackage before there isn't at least
a beta/RC of GHC 8.8 as only then the `base`-API would be
reasonably stable/frozen for base-4.13.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/haskeline/104)
<!-- Reviewable:end -->
