### PR TITLE
Convert the test to a test-suite.

### DIFF
--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -112,17 +112,17 @@ Library
 
     ghc-options: -Wall
 
-Executable haskeline-tests
+test-suite haskeline-tests
+    type: exitcode-stdio-1.0
     hs-source-dirs: tests
     Default-Language: Haskell98
 
     if os(windows)
-        Main-is: NotExisting.hs
         buildable: False
-    else
-        Main-Is:    Unit.hs
-        Build-depends: base, containers, text, bytestring, HUnit, process, unix
-        Other-Modules: RunTTY, Pty
+    Main-Is:    Unit.hs
+    Build-depends: base, containers, text, bytestring, HUnit, process, unix
+    Other-Modules: RunTTY, Pty
+    build-tool-depends: haskeline:haskeline-examples-Test
 
 -- The following program is used by unit tests in `tests` executable
 Executable haskeline-examples-Test

--- a/tests/RunTTY.hs
+++ b/tests/RunTTY.hs
@@ -11,12 +11,12 @@ module RunTTY (Invocation(..),
             setUTF8
             ) where
 
-import Data.ByteString as B
-import qualified Data.ByteString.Char8 as BC
-import System.Process
 import Control.Concurrent
+import Data.ByteString as B
 import System.IO
+import System.Process
 import Test.HUnit
+import qualified Data.ByteString.Char8 as BC
 
 import Pty
 


### PR DESCRIPTION
This works with `stack` and `cabal new-test`.  The latter
uses the `build-tool-depends` field to locate the binary.

Also:
- Remove the reference to the nonexistent main file on Windows.
- Make the test binary return a nonzero exit code when it fails.

Still TODO: test in CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/haskeline/110)
<!-- Reviewable:end -->
