### PR TITLE
Turn debugTerminalKeys into a single loop.

### DIFF
--- a/System/Console/Haskeline/Internal.hs
+++ b/System/Console/Haskeline/Internal.hs
@@ -1,7 +1,6 @@
 module System.Console.Haskeline.Internal
     ( debugTerminalKeys ) where
 
-import Control.Monad (forever)
 import System.Console.Haskeline (defaultSettings, outputStrLn)
 import System.Console.Haskeline.Command
 import System.Console.Haskeline.InputT
@@ -19,16 +18,17 @@ import System.Console.Haskeline.Term
 -- Haskeline's behavior may be modified by editing your @~/.haskeline@
 -- file.  For details, see: <https://github.com/judah/haskeline/wiki/CustomKeyBindings>
 --
-debugTerminalKeys :: IO ()
+debugTerminalKeys :: IO a
 debugTerminalKeys = runInputT defaultSettings $ do
     outputStrLn
         "Press any keys to debug Haskeline's input, or ctrl-c to exit:"
     rterm <- InputT ask
     case termOps rterm of
         Right _ -> error "debugTerminalKeys: not run in terminal mode"
-        Left tops -> forever $ getKey tops >>= outputStrLn . show
+        Left tops -> runInputCmdT tops $ runCommandLoop tops prompt
+                                            loop emptyIM
   where
-    getKey tops = runInputCmdT tops
-                    $ runCommandLoop tops prompt getKeyCmd emptyIM
-    getKeyCmd = KeyMap $ \k -> Just $ Consumed $ const $ return k
+    loop = KeyMap $ \k -> Just $ Consumed $
+            (\s -> effect (PrintLines [show k]) >> return s)
+            >|> keyCommand loop
     prompt = stringToGraphemes "> "


### PR DESCRIPTION
Make it a looped KeyCommand inside a single call to runInputCmdT,
rather than calling runInputCmdT once for each character.

This hopefully makes it closer to "real" results when entering
multiple keys (e.g., holding them down).