### PR TITLE
Add a MonadFail instance for InputT.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,6 @@
+Next
+   * Added a `MonadFail` instance for `InputT`.
+
 Changed in version 0.7.5.0:
    * Add the new function `fallbackCompletion` to combine
      multiple `CompletionFunc`s

--- a/System/Console/Haskeline/InputT.hs
+++ b/System/Console/Haskeline/InputT.hs
@@ -13,6 +13,7 @@ import System.Console.Haskeline.Term
 
 import Control.Exception (IOException)
 import Control.Monad.Catch
+import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Data.IORef
 import System.Directory(getHomeDirectory)
@@ -57,6 +58,9 @@ newtype InputT m a = InputT {unInputT ::
 
 instance MonadTrans InputT where
     lift = InputT . lift . lift . lift . lift . lift
+
+instance ( Fail.MonadFail m ) => Fail.MonadFail (InputT m) where
+    fail = lift . Fail.fail
 
 instance ( MonadFix m ) => MonadFix (InputT m) where
     mfix f = InputT (mfix (unInputT . f))


### PR DESCRIPTION
There are also a couple of other monads that could plausibly have this
instance, but since none of them seem to be exported I left them alone.