### PR TITLE
Eta expand as required by simplified subsumption rules

### DIFF
--- a/System/Console/Haskeline/Backend/DumbTerm.hs
+++ b/System/Console/Haskeline/Backend/DumbTerm.hs
@@ -39,7 +39,7 @@ runDumbTerm h = liftIO $ posixRunTerm h (posixLayouts h) [] id evalDumb
                                 
 instance (MonadIO m, MonadMask m, MonadReader Layout m) => Term (DumbTerm m) where
     reposition _ s = refitLine s
-    drawLineDiff = drawLineDiff'
+    drawLineDiff x y = drawLineDiff' x y
     
     printLines = mapM_ (printText . (++ crlf))
     moveToNextLine _ = printText crlf

--- a/System/Console/Haskeline/Backend/Terminfo.hs
+++ b/System/Console/Haskeline/Backend/Terminfo.hs
@@ -202,7 +202,7 @@ output t = Writer.tell t  -- NB: explicit argument enables build with ghc-6.12.3
                           -- see GHC ticket #1749).
 
 outputText :: String -> ActionM ()
-outputText = output . const . termText
+outputText s = output (const (termText s))
 
 left,right,up :: Int -> TermAction
 left = flip leftA
@@ -238,7 +238,7 @@ moveToPos p = do
 
 moveRelative :: Int -> ActionM ()
 moveRelative n = liftM3 (advancePos n) ask get get
-                    >>= moveToPos
+                    >>= \p -> moveToPos p
 
 -- Note that these move by a certain number of cells, not graphemes.
 changeRight, changeLeft :: Int -> ActionM ()


### PR DESCRIPTION
This will be necessary to compile with GHC 8.12. See GHC Proposal 287:
https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst

I have submitted this against `haskeline-0.8` due to #133 but this will ultimately need to end up on `master` as well.