### PR TITLE
Add import list to Data.List

### DIFF
--- a/System/Console/Haskeline/Backend/Posix.hsc
+++ b/System/Console/Haskeline/Backend/Posix.hsc
@@ -25,7 +25,7 @@ import Control.Concurrent hiding (throwTo)
 import Data.Maybe (catMaybes)
 import System.Posix.Signals.Exts
 import System.Posix.Types(Fd(..))
-import Data.List
+import Data.Foldable (foldl')
 import System.IO
 import System.Environment
 

--- a/System/Console/Haskeline/Backend/WCWidth.hs
+++ b/System/Console/Haskeline/Backend/WCWidth.hs
@@ -10,7 +10,7 @@ module System.Console.Haskeline.Backend.WCWidth(
 
 import System.Console.Haskeline.LineState
 
-import Data.List
+import Data.List (foldl')
 import Foreign.C.Types
 
 foreign import ccall unsafe haskeline_mk_wcwidth :: CInt -> CInt

--- a/System/Console/Haskeline/Command/History.hs
+++ b/System/Console/Haskeline/Command/History.hs
@@ -5,7 +5,7 @@ import System.Console.Haskeline.Command
 import System.Console.Haskeline.Key
 import Control.Monad(liftM,mplus)
 import System.Console.Haskeline.Monads
-import Data.List
+import Data.List (isPrefixOf, unfoldr)
 import Data.Maybe(fromMaybe)
 import System.Console.Haskeline.History
 import Data.IORef

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -117,7 +117,7 @@ Library
         }
     }
 
-    ghc-options: -Wall
+    ghc-options: -Wall -Wcompat
 
 test-suite haskeline-tests
     type: exitcode-stdio-1.0


### PR DESCRIPTION
This will avoid future breakage

See https://downloads.haskell.org/ghc/8.10.3/docs/html/users_guide/using-warnings.html?highlight=wcompat#ghc-flag--Wcompat-unqualified-imports