### PR TITLE
Use capi rather than ccall to import ioctl

### DIFF
--- a/System/Console/Haskeline/Backend/Posix.hsc
+++ b/System/Console/Haskeline/Backend/Posix.hsc
@@ -1,3 +1,5 @@
+{-# LANGUAGE CApiFFI #-}
+
 module System.Console.Haskeline.Backend.Posix (
                         withPosixGetEvent,
                         posixLayouts,
@@ -61,7 +63,7 @@ ehOut = eH . hOut
 -------------------
 -- Window size
 
-foreign import ccall ioctl :: FD -> CULong -> Ptr a -> IO CInt
+foreign import capi "sys/ioctl.h ioctl" ioctl :: FD -> CULong -> Ptr a -> IO CInt
 
 posixLayouts :: Handles -> [IO (Maybe Layout)]
 posixLayouts h = [ioctlLayout $ ehOut h, envLayout]


### PR DESCRIPTION
As noted by GHC #20085, the ccall calling convention does not support
variadic functions like `ioctl`.