### PR TITLE
Drop read thread

### DIFF
--- a/System/Console/Haskeline/Backend/Win32.hsc
+++ b/System/Console/Haskeline/Backend/Win32.hsc
@@ -66,8 +66,6 @@ eventReader :: HANDLE -> IO [Event]
 eventReader h = do
     let waitTime = 500 -- milliseconds
     ret <- c_WaitForSingleObject h waitTime
-    yield -- otherwise, the above foreign call causes the loop to never
-          -- respond to the killThread
     if ret /= (#const WAIT_OBJECT_0)
         then eventReader h
         else do


### PR DESCRIPTION
Previously we would read events from the console in a separate thread
which would be killed after the needed event was read. There are a few
issues with this approach:

 * it is expensive, requiring the creation and destruction of a thread
   with every read event
 * it is racy, since the thread may be killed after an even has been
   read from the console but before it has been pushed to the event
   TChan
 * we may read too much: the read loop thread may read more input than
   Haskeline was supposed to read (see GHC #21047).
