### PR TITLE
Add `mapInputT_`

### DIFF
--- a/System/Console/Haskeline.hs
+++ b/System/Console/Haskeline.hs
@@ -33,6 +33,7 @@ module System.Console.Haskeline(
                     runInputT,
                     haveTerminalUI,
                     mapInputT,
+                    mapInputT_,
                     -- ** Behaviors
                     Behavior,
                     runInputTBehavior,

--- a/System/Console/Haskeline/InputT.hs
+++ b/System/Console/Haskeline/InputT.hs
@@ -189,6 +189,11 @@ mapInputT f = InputT . mapReaderT (mapReaderT (mapReaderT
                                   (mapReaderT (mapReaderT f))))
                     . unInputT
 
+mapInputT_ :: (m () -> m ()) -> InputT m () -> InputT m ()
+mapInputT_ f = InputT . mapReaderT (mapReaderT (mapReaderT
+                                  (mapReaderT (mapReaderT f))))
+                    . unInputT
+
 -- | Read input from 'stdin'.  
 -- Use terminal-style interaction if 'stdin' is connected to
 -- a terminal and has echoing enabled.  Otherwise (e.g., if 'stdin' is a pipe), use


### PR DESCRIPTION
Add a variation of `mapInputT` that only works on the unit type.