### PR TITLE
Bump base bound to <4.20

### DIFF
--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -49,7 +49,7 @@ Library
     -- We require ghc>=7.4.1 (base>=4.5) to use the base library encodings, even
     -- though it was implemented in earlier releases, due to GHC bug #5436 which
     -- wasn't fixed until 7.4.1
-    Build-depends: base >=4.9 && < 4.19, containers>=0.4 && < 0.7,
+    Build-depends: base >=4.9 && < 4.20, containers>=0.4 && < 0.7,
                    directory>=1.1 && < 1.4, bytestring>=0.9 && < 0.12,
                    filepath >= 1.2 && < 1.5, transformers >= 0.2 && < 0.7,
                    process >= 1.0 && < 1.7, stm >= 2.4 && < 2.6,


### PR DESCRIPTION
For GHC 9.8.