### PR TITLE
add getInputChar' which reads any character not just printable

### DIFF
--- a/System/Console/Haskeline.hs
+++ b/System/Console/Haskeline.hs
@@ -46,6 +46,7 @@ module System.Console.Haskeline(
                     getInputLine,
                     getInputLineWithInitial,
                     getInputChar,
+                    getInputChar',
                     getPassword,
                     waitForAnyKey,
                     -- ** Outputting text
@@ -231,6 +232,20 @@ acceptOneChar = choiceCmd [useChar $ \c s -> change (insertChar c) s
                           , ctrlChar 'l' +> clearScreenCmd >|>
                                         keyCommand acceptOneChar
                           , ctrlChar 'd' +> failCmd]
+
+{- | Reads one character of input, including non-printable.
+-}
+getInputChar' :: (MonadIO m, MonadMask m) => String -- ^ The input prompt
+              -> InputT m (Maybe Char)
+getInputChar' = promptedInput getInputCmdChar' $
+  runMaybeT . getLocaleChar
+
+getInputCmdChar' :: (MonadIO m, MonadMask m) => TermOps -> Prefix -> InputT m (Maybe Char)
+getInputCmdChar' tops prefix = runInputCmdT tops
+        $ runCommandLoop tops prefix acceptOneChar' emptyIM
+
+acceptOneChar' :: Monad m => KeyCommand m InsertMode (Maybe Char)
+acceptOneChar' = useChar' $ \c _s -> return (Just c)
 
 ----------
 {- | Waits for one key to be pressed, then returns.  Ignores the value

--- a/System/Console/Haskeline/Command.hs
+++ b/System/Console/Haskeline/Command.hs
@@ -22,6 +22,7 @@ module System.Console.Haskeline.Command(
                         changeFromChar,
                         (+>),
                         useChar,
+                        useChar',
                         choiceCmd,
                         keyChoiceCmd,
                         keyChoiceCmdM,
@@ -94,6 +95,12 @@ useKey k x = KeyMap $ \k' -> if k==k' then Just (Consumed x) else Nothing
 useChar :: (Char -> Command m s t) -> KeyCommand m s t
 useChar act = KeyMap $ \k -> case k of
                     Key m (KeyChar c) | isPrint c && m==noModifier
+                        -> Just $ Consumed (act c)
+                    _ -> Nothing
+
+useChar' :: (Char -> Command m s t) -> KeyCommand m s t
+useChar' act = KeyMap $ \k -> case k of
+                    Key _m (KeyChar c)
                         -> Just $ Consumed (act c)
                     _ -> Nothing
 


### PR DESCRIPTION
A general variant of `getInputChar` which also reads non-printable characters like `'\n'` etc.

A better or more descriptive name might be `getAnyChar` or `getInputCharAny` perhaps?